### PR TITLE
Remove "Hardened Clay" because conflict with backedclay mod

### DIFF
--- a/recipes.lua
+++ b/recipes.lua
@@ -171,14 +171,6 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "xdecor:hard_clay",
-	recipe = {
-		{"default:clay", "default:clay"},
-		{"default:clay", "default:clay"}
-	}
-})
-
-minetest.register_craft({
 	output = "xdecor:hive",
 	recipe = {
 		{"group:stick", "group:stick", "group:stick"},


### PR DESCRIPTION
Because not impossible to cook "backed clay" from backedclay mod or "hardened clay" from colored_clay mod (if installed) and "xdecor:hard_clay" not using in xdecor.