### PR TITLE
Use stairs mod inner/outer nodes.

### DIFF
--- a/src/workbench.lua
+++ b/src/workbench.lua
@@ -60,12 +60,9 @@ workbench.defs = {
 			    { 0, 8,  8, 16, 8, 8  }},
 	{"halfstair",	2,  { 0, 0,  0, 8,  8, 16 },
 			    { 0, 8,  8, 8,  8, 8  }},
-	{"outerstair",	1,  { 0, 0,  0, 16, 8, 16 },
-			    { 0, 8,  8, 8,  8, 8  }},
+	{"stair_outer",	1,  nil			  },
 	{"stair",	1,  nil			  },
-	{"innerstair",	1,  { 0, 0,  0, 16, 8, 16 },
-			    { 0, 8,  8, 16, 8, 8  },
-			    { 0, 8,  0, 8,  8, 8  }}
+	{"stair_inner",	1,  nil			  }
 }
 
 -- Tools allowed to be repaired


### PR DESCRIPTION
This may need improvement depending on how new these inner/outer stairs are in minetest_game.  It's missing aliases, but, this uses the new inner/outer stairs nodes from stairs mod so there's not duplicates registered.