### PR TITLE
Fix crash when user tries to open non-owned locked doors through pressureplate

### DIFF
--- a/src/mechanisms.lua
+++ b/src/mechanisms.lua
@@ -14,14 +14,14 @@ local function door_toggle(pos_actuator, pos_door, player)
 		minetest.set_node(pos_actuator,
 			{name=actuator.name:gsub("_off", "_on"), param2=actuator.param2})
 	end
-	door:open(player_name)
+	door:open(player)
 
 	minetest.after(2, function()
 		if minetest.get_node(pos_actuator).name:sub(-3) == "_on" then
 			minetest.set_node(pos_actuator,
 				{name=actuator.name, param2=actuator.param2})
 		end
-		door:close(player_name)
+		door:close(player)
 	end)
 end
 


### PR DESCRIPTION
This PR fixes issue #98.