### PR TITLE
Chess: Fix queen-side castling and king-side castling for black

### DIFF
--- a/src/chess.lua
+++ b/src/chess.lua
@@ -1096,7 +1096,7 @@ function realchess.move(pos, from_list, from_index, to_list, to_index, _, player
 
 		if thisMove == "white" then
 			if from_y == 7 and to_y == 7 then
-				if to_x == 1 then
+				if to_x == 2 then
 					local castlingWhiteL = meta:get_int("castlingWhiteL")
 					local idx57 = inv:get_stack(from_list, 57):get_name()
 
@@ -1108,7 +1108,7 @@ function realchess.move(pos, from_list, from_index, to_list, to_index, _, player
 						end
 
 						inv:set_stack(from_list, 57, "")
-						inv:set_stack(from_list, 59, "realchess:rook_white_1")
+						inv:set_stack(from_list, 60, "realchess:rook_white_1")
 						check = false
 					end
 				elseif to_x == 6 then
@@ -1130,7 +1130,7 @@ function realchess.move(pos, from_list, from_index, to_list, to_index, _, player
 			end
 		elseif thisMove == "black" then
 			if from_y == 0 and to_y == 0 then
-				if to_x == 1 then
+				if to_x == 2 then
 					local castlingBlackL = meta:get_int("castlingBlackL")
 					local idx1 = inv:get_stack(from_list, 1):get_name()
 
@@ -1142,7 +1142,7 @@ function realchess.move(pos, from_list, from_index, to_list, to_index, _, player
 						end
 
 						inv:set_stack(from_list, 1, "")
-						inv:set_stack(from_list, 3, "realchess:rook_black_1")
+						inv:set_stack(from_list, 4, "realchess:rook_black_1")
 						check = false
 					end
 				elseif to_x == 6 then

--- a/src/chess.lua
+++ b/src/chess.lua
@@ -1147,7 +1147,7 @@ function realchess.move(pos, from_list, from_index, to_list, to_index, _, player
 					end
 				elseif to_x == 6 then
 					local castlingBlackR = meta:get_int("castlingBlackR")
-					local idx8 = inv:get_stack(from_list, 1):get_name()
+					local idx8 = inv:get_stack(from_list, 8):get_name()
 
 					if castlingBlackR == 1 and idx8 == "realchess:rook_black_2" then
 						for i = from_index + 1, 7 do


### PR DESCRIPTION
In the code for black short-castling, the presence of rook_black_2 is checked on the wrong field (1 instead of 8, where rook_black_1 is placed initially), which prevents black from short-castling. (This was probably overlooked when copying the logic from the long-castling check directly above.)

After making this change, so that `idx8` indeed refers to the figure on field 8, castling indeed works as expected.

Edit: And while we're at it, as issue #120 points out, the king should move two squares towards the rook when queen-side castling. This is now fixed in the second commit.