### PR TITLE
Edit cobweb craft to use farming:string instead of farming:cotton

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = xdecor
-depends = default, bucket, doors, stairs, xpanes
+depends = default, bucket, doors, stairs, xpanes, farming
 optional_depends = fire, oresplus, moreblocks, mesecons
 description = A decoration mod meant to be simple and well-featured.

--- a/src/recipes.lua
+++ b/src/recipes.lua
@@ -66,9 +66,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "xdecor:cobweb",
 	recipe = {
-		{"farming:cotton", "", "farming:cotton"},
-		{"", "farming:cotton", ""},
-		{"farming:cotton", "", "farming:cotton"}
+		{"farming:string", "", "farming:string"},
+		{"", "farming:string", ""},
+		{"farming:string", "", "farming:string"}
 	}
 })
 


### PR DESCRIPTION
- Add `farming` to depends, since it was missing

Closes #128.