### PR TITLE
remove untranslateable chars from Buttontext

### DIFF
--- a/locale/template.txt
+++ b/locale/template.txt
@@ -145,7 +145,7 @@ Rope=
 
 ### workbench.lua ###
 
-Back=
+< Back=
 Crafting=
 Cut=
 Hammer=

--- a/locale/xdecor.fr.tr
+++ b/locale/xdecor.fr.tr
@@ -145,7 +145,7 @@ Rope=Corde
 
 ### workbench.lua ###
 
-Back=Retour
+Back=< Retour
 Crafting=Fabrication
 Cut=Couper
 Hammer=Marteau

--- a/src/workbench.lua
+++ b/src/workbench.lua
@@ -102,7 +102,7 @@ local main_fs = "label[0.9,1.23;"..FS("Cut").."]"
 ]]
 
 local crafting_fs = "image[5,1;1,1;gui_furnace_arrow_bg.png^[transformR270]"
-	.."button[0,0;1.5,1;back;"..FS("Back").."]"
+	.."button[0,0;1.5,1;back;"..FS("< Back").."]"
 	..[[ list[current_player;craft;2,0;3,3;]
 	list[current_player;craftpreview;6,1;1,1;]
 	listring[current_player;main]
@@ -110,7 +110,7 @@ local crafting_fs = "image[5,1;1,1;gui_furnace_arrow_bg.png^[transformR270]"
 ]]
 
 local storage_fs = "list[context;storage;0,1;8,2;]"
-	.."button[0,0;1.5,1;back;"..FS("Back").."]"
+	.."button[0,0;1.5,1;back;"..FS("< Back").."]"
 	..[[listring[context;storage]
 	listring[current_player;main]
 ]]

--- a/src/workbench.lua
+++ b/src/workbench.lua
@@ -102,7 +102,7 @@ local main_fs = "label[0.9,1.23;"..FS("Cut").."]"
 ]]
 
 local crafting_fs = "image[5,1;1,1;gui_furnace_arrow_bg.png^[transformR270]"
-	.."button[0,0;1.5,1;back;< "..FS("Back").."]"
+	.."button[0,0;1.5,1;back;"..FS("Back").."]"
 	..[[ list[current_player;craft;2,0;3,3;]
 	list[current_player;craftpreview;6,1;1,1;]
 	listring[current_player;main]
@@ -110,7 +110,7 @@ local crafting_fs = "image[5,1;1,1;gui_furnace_arrow_bg.png^[transformR270]"
 ]]
 
 local storage_fs = "list[context;storage;0,1;8,2;]"
-	.."button[0,0;1.5,1;back;< "..FS("Back").."]"
+	.."button[0,0;1.5,1;back;"..FS("Back").."]"
 	..[[listring[context;storage]
 	listring[current_player;main]
 ]]


### PR DESCRIPTION
This specific Button has the Caption **"< Back"** (with only "Back" translateable)
There is no Explanation, why "Back" is to the left. Or is the Caption "less than Back"?

A Button usually has the caption "Forward" or "Back" or "Select" or "Crafting". No extra directional signs.
