### PR TITLE
Make the hive inventory respect area protection

### DIFF
--- a/src/hive.lua
+++ b/src/hive.lua
@@ -71,6 +71,13 @@ xdecor.register("hive", {
 		return 0
 	end,
 
+	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
+		if minetest.is_protected(pos, player:get_player_name()) then
+			return 0
+		end
+		return stack:get_count()
+	end,
+
 	on_metadata_inventory_take = function(pos, _, _, stack)
 		if stack:get_count() == honey_max then
 			local timer = minetest.get_node_timer(pos)


### PR DESCRIPTION
Fixes BLS issue 199 https://github.com/BlockySurvival/issue-tracker/issues/199

Added an `allow_metadata_inventory_take` callback that stops players stealing honey from a protected area