### PR TITLE
Add Method for Other Mods to Check if Items are Repairable

### DIFF
--- a/src/workbench.lua
+++ b/src/workbench.lua
@@ -52,6 +52,11 @@ function workbench:repairable(stack)
 	end
 end
 
+-- method to allow other mods to check if an item is repairable
+function xdecor:is_repairable(stack)
+	return workbench:repairable(stack)
+end
+
 function workbench:get_output(inv, input, name)
 	local output = {}
 	for i = 1, #self.defs do


### PR DESCRIPTION
~~Exposes `workbench.repairable` method via `xdecor.workbench_repairable` to mods so they can use it to check if an item is repairable.~~

Adds `xdecor:is_repairable` method for mods to check if an item is repairable with workbench.