### PR TITLE
add description (and translations) for cauldron_{idle,boiling,soup}

### DIFF
--- a/locale/template.txt
+++ b/locale/template.txt
@@ -36,6 +36,7 @@ check=
 Bowl=
 Bowl of soup=
 Cauldron=
+Cauldron (active)=
 Cauldron (active) - Drop foods inside to make a soup=
 Cauldron (active) - Use a bowl to eat the soup=
 Cauldron (empty)=

--- a/locale/xdecor.de.tr
+++ b/locale/xdecor.de.tr
@@ -34,6 +34,7 @@ check=Schach
 Bowl=Schüssel
 Bowl of soup=Suppenschüssel
 Cauldron=Kessel
+Cauldron (active)=Kessel (aktiv)
 Cauldron (active) - Drop foods inside to make a soup=Kessel (aktiv) - Nahrungsmittel einwerfen, um Suppe zu machen.
 Cauldron (active) - Use a bowl to eat the soup=Kessel (aktiv) - Benutze eine Schüssel, um die Suppe zu essen
 Cauldron (empty)=Kessel (leer)

--- a/locale/xdecor.fr.tr
+++ b/locale/xdecor.fr.tr
@@ -36,6 +36,7 @@ check=échec
 Bowl=Bol
 Bowl of soup=Bol de soupe
 Cauldron=Chaudron
+Cauldron (active)=Chaudron (actif)
 Cauldron (active) - Drop foods inside to make a soup=Chaudron (actif) - Placez des ingrédients à l’intérieur pour faire une soupe
 Cauldron (active) - Use a bowl to eat the soup=Chaudron (actif) - Utilisez un bol pour boire la soupe
 Cauldron (empty)=Chaudron (vide)

--- a/locale/xdecor.it.tr
+++ b/locale/xdecor.it.tr
@@ -36,6 +36,7 @@ check=scacco
 Bowl=Ciotola
 Bowl of soup=Ciotola di zuppa
 Cauldron=Calderone
+Cauldron (active)=Calderone (attivo)
 Cauldron (active) - Drop foods inside to make a soup=Calderone (attivo) - Mettere gli ingredienti all'interno per fare una zuppa.
 Cauldron (active) - Use a bowl to eat the soup=Calderone (actif) - Utilizzare una ciotola per mangiare la zuppa
 Cauldron (empty)=Calderone (vuoto)

--- a/src/cooking.lua
+++ b/src/cooking.lua
@@ -173,6 +173,7 @@ xdecor.register("cauldron_empty", {
 })
 
 xdecor.register("cauldron_idle", {
+	description = S("Cauldron (idle)"),
 	groups = {cracky=2, oddly_breakable_by_hand=1, not_in_creative_inventory=1},
 	on_rotate = screwdriver.rotate_simple,
 	tiles = {"xdecor_cauldron_top_idle.png", "xdecor_cauldron_sides.png"},
@@ -185,6 +186,7 @@ xdecor.register("cauldron_idle", {
 })
 
 xdecor.register("cauldron_boiling", {
+	description = S("Cauldron (active)"),
 	groups = {cracky=2, oddly_breakable_by_hand=1, not_in_creative_inventory=1},
 	on_rotate = screwdriver.rotate_simple,
 	drop = "xdecor:cauldron_empty",
@@ -207,6 +209,7 @@ xdecor.register("cauldron_boiling", {
 })
 
 xdecor.register("cauldron_soup", {
+	description = S("Cauldron (active)"),
 	groups = {cracky = 2, oddly_breakable_by_hand = 1, not_in_creative_inventory = 1},
 	on_rotate = screwdriver.rotate_simple,
 	drop = "xdecor:cauldron_empty",


### PR DESCRIPTION
This PR adds  description and translations for cauldron_{idle,boiling,soup}

So the description in the inventory would be shorter after pick up with the wrench https://github.com/mt-mods/wrench/pull/2